### PR TITLE
Compatibility with Symfony 3.0 and PHP7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "symfony/process": "~2.6"
+        "symfony/process": "~2.6|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.2",

--- a/src/FileFormat.php
+++ b/src/FileFormat.php
@@ -107,7 +107,7 @@ class FileFormat
         }
 
         $str = substr($basename, $pos + 1);
-        if (false === $str) {
+        if (false === $str || '' === $str) {
             return null;
         }
 


### PR DESCRIPTION
I changed the composer dependency on Symfony to support 3.0. It looks like your library works out of the house with Symfony 3.0. The unit tests are working and I generated a document to test it.

Furthermore, I made a change to support PHP7. Within PHP7, substr() returns an empty string if the length of the input string equals the start position.
